### PR TITLE
Make destination16 optional

### DIFF
--- a/__tests__/test-zdo.js
+++ b/__tests__/test-zdo.js
@@ -77,6 +77,22 @@ describe(zci[zci.NETWORK_ADDRESS_REQUEST], () => {
     expect(frame.data).toEqual(expectedData);
     dumpFrame('Req', frame);
   });
+  it('Build Frame with no destination16', () => {
+    const frame = Object.assign({
+      clusterId: zci.NETWORK_ADDRESS_REQUEST,
+      addr64: '1122334455667788',
+      requestType: 0,
+      startIndex: 0,
+    }, defaultFrame);
+    delete frame.destination16;
+    zdoObj.makeFrame(frame);
+    expect(frame.destination16).toEqual('fffe');
+    const expectedData = Buffer.from([
+      0xee, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00, 0x00,
+    ]);
+    expect(frame.data).toEqual(expectedData);
+    dumpFrame('Req', frame);
+  });
   it('Parse frame', () => {
     const frame = Object.assign({
       clusterId: zci.NETWORK_ADDRESS_REQUEST,
@@ -1460,14 +1476,6 @@ describe('makeFrame coverage', () => {
   });
   it('missing destination64', () => {
     const frame = {};
-    expect(() => {
-      zdoObj.makeFrame(frame);
-    }).toThrow();
-  });
-  it('missing destination16', () => {
-    const frame = {
-      destination64: '01234567891bcdef',
-    };
     expect(() => {
       zdoObj.makeFrame(frame);
     }).toThrow();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zigbee-zdo",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Module for building/parsing Zigbee ZDO frames.",
   "main": "zdo.js",
   "scripts": {
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",
-    "eslint": "^5.10.0",
+    "eslint": "^5.12.1",
     "jest": "^23.6.0"
   }
 }

--- a/zdo.js
+++ b/zdo.js
@@ -200,9 +200,13 @@ class ZdoApi {
   makeFrame(frame) {
     assert(frame, 'Frame parameter must be a frame object');
     assert(frame.destination64, 'Caller must provide frame.destination64');
-    assert(frame.destination16, 'Caller must provide frame.destination16');
     assert(typeof frame.clusterId !== 'undefined',
            'Caller must provide frame.clusterId');
+
+    if (!frame.destination16) {
+      // 16-bit address is unknown.
+      frame.destination16 = 'fffe';
+    }
 
     const clusterId = getClusterIdAsInt(frame.clusterId);
     // Convert the clusterId to its hex form. This is easier to
@@ -486,7 +490,7 @@ zdoParser[zci.END_DEVICE_ANNOUNCEMENT] = function(frame, reader) {
 };
 
 zdoDump[zci.END_DEVICE_ANNOUNCEMENT] = function(frame) {
-  return `Addr:${frame.addr64} ${frame.addr16} ` +
+  return `Addr:${frame.zdoAddr64} ${frame.zdoAddr16} ` +
          `FFD:${frame.fullFunctionDevice} ` +
          `AC:${frame.acPower} ` +
          `rxOnWhenIdle:${frame.rxOnWhenIdle}`;


### PR DESCRIPTION
It will now fill in destination16 with the 'fffe' which
is the unknown 16-bit address if it isn't provided.